### PR TITLE
This adds a habit form to the list_habits template and creates an add…

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,13 +1,18 @@
 from django import forms
 from .models import Habit
 
-class BookForm(forms.ModelForm):
-    class Meta:
-        model = Habit
-        fields = [
-            "verb",
-            "noun",
-            "noun_singular",
-            "number",
-            "is_negative"
-        ]
+class HabitForm(forms.Form):
+
+    CHOICES = [ ("more", "at least"), ("less", "less than") ]
+
+    verb = forms.CharField(max_length=20,  widget= forms.TextInput
+                           (attrs={'placeholder':'verb'}))
+    noun = forms.CharField(max_length=20, widget= forms.TextInput
+                           (attrs={'placeholder':'plural noun'}))
+    noun_singular = forms.CharField(max_length=20, widget= forms.TextInput
+                           (attrs={'placeholder':'noun'}))
+    number = forms.FloatField(widget= forms.TextInput
+                           (attrs={'placeholder':'number'}))
+    more_less = forms.ChoiceField(choices=CHOICES, widget=forms.RadioSelect)
+
+

--- a/core/views.py
+++ b/core/views.py
@@ -1,20 +1,45 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from .models import Habit, Record
+from .forms import HabitForm
+from datetime import date
 from users.models import User
+import logging
 
 # Create your views here.
 def list_habits(request):
+    logging.error('Ran list_habits')
     user = request.user
     habits = user.habits.all()
-    return render(request, 'core/list_habits.html', { "habits" : habits })
+    form = HabitForm()
+    return render(request, 'core/list_habits.html', { "habits" : habits, "form" : form})
 
 def show_habit(request, pk):
     habit = get_object_or_404(Habit, pk=pk)
     return render(request, 'core/show_habit.html', {"habit": habit})
 
+# This may require that we change the way dates are implemented either here or in the model.  Auto_now_add
+# is not set in the model to make it easier for DB entry creation of multiple dates.  Needs to be decided and
+# addressed before production
 def add_habit(request):
-    pass
+    logging.error("Running add_habit")
+    form = HabitForm(data=request.POST)
+    user = request.user
+    is_negative = False
+    habit = None
+    if form.is_valid():
+        noun = form.cleaned_data.get('noun')
+        noun_singular = form.cleaned_data.get('noun_singular')
+        number = form.cleaned_data.get('number')
+        more_less = form.cleaned_data.get('more_less')
+        verb = form.cleaned_data.get('verb')
+        if (more_less == "less"):
+            is_negative = True
+        habit = Habit(verb=verb, noun=noun, noun_singular=noun_singular, number=number, is_negative=is_negative, user=user, created_date=date.today())
+        habit.save()
+    else: 
+        logging.error("Form not valid.")
+    return redirect(to="list_habits")
 
 def edit_habit(request, pk):
     pass

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -58,6 +58,23 @@ header {
     border: 1px solid black;
 }
 
+
+/* Form CSS */
+.inline-radio {
+	display: flex;
+    border-radius: 3px;
+	overflow: hidden;
+}
+
+.habit-form-div {
+    border: 1px solid black;
+}
+
+
+
+
+
+
 .met {
     background-color: rgb(98, 199, 98);
 }

--- a/templates/core/list_habits.html
+++ b/templates/core/list_habits.html
@@ -30,4 +30,43 @@
     </div>
     {% endfor %}
 </div>
+<div class="habit-form-div">
+    <form action="{% url 'add_habit' %}" class="" method="POST">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        {{ form.verb.errors }}
+        <p>I would like to {{ form.verb }}</p>
+        <div class="inline-radio">
+            <group class="inline-radio">
+                {% for radio in form.more_less %}
+                {{ radio }}
+                {% endfor %}
+            </group>
+            <span>{{form.number}}</span>
+            {{form.number.errors}}
+        </div>
+        {{form.noun_singular.errors}}  {{form.noun.errors}}
+        <p>{{form.noun_singular}} / {{form.noun}} per day.</p>
+        <input type="submit" value="Create Habit">
+    </form>
+</div>
 {% endblock %}
+
+<!-- 
+The folowing is just a traditional HTML mockup of the form so I could figure out how I wanted to lay out
+the Django version, since I wasn't used to manually dealing with Django fields in the way I do below.
+    
+<div class="habit-form-div">
+    <form action="{% url 'add_habit' %}" class="" method="get">
+        <p>I would like to <input name="habit_verb" type="text" placeholder="verb"></p>
+        <div class="inline-radio">
+            <group class="inline-radio">
+                <div><input type="radio" name="more-less" value="more"><label>at least</label></div> / 
+                <div><input type="radio" name="more-less" value="less"><label>less than</label></div>
+            </group>  
+            <input name="habit-number" type="number" placeholder="number">
+        </div>
+        <p><input name="habit_noun_singular" type="text" placeholder="noun"> / <input name="habit_noun_plural" type="text" placeholder="noun_plural"></p>
+        <input type="submit" value="Create Habit">
+    </form>
+</div> -->


### PR DESCRIPTION
…_habit view logic

The HabitForm is not a ModelForm to allow for a little more clarity in the more than/less than toggles that a user can access...maybe there was a way to do that in a ModelForm, but this gave me a chance to play around with and learn how to use a generic form and pull info off of it.  Was able to show individual fields and add CSS tags and such so we're not stuck with generic Django _as_p _as_ul kinds of things....

Two potential issues/things to consider.  We are not currently auto-adding dates to our habits in order to make creation of various habits at different "times" easier.  So there's a spot in habit creation where I'm manually setting the date to date.today().  We can either keep this in or change the field to auto_now_add when we get closer to production.

Next, given the way I set up the form, noun and noun_singular are redundant (and just plain confusing).  We can simplify a lot of logic if we take the singular out and just allow the user to input the appropriate noun in the space.  We don't have to enforce their good grammar, despite that being tempting.  

Again, this is all there on the page with no particular styling.  That can come later.  The logic is working, and habits can now be created.  We can later hide that form as necessary to allow JS to show it when a user wants to add a habit.  

Something to think on:  How will we check to see if a Record has been created on all consecutive days in order to prompt the user to fill in blanks they may have missed?
<img width="423" alt="Screen Shot 2020-07-04 at 5 05 43 PM" src="https://user-images.githubusercontent.com/65555129/86521039-83a04500-be19-11ea-93ab-4262eff00a79.png">
